### PR TITLE
Fix what is in bert notebook

### DIFF
--- a/assets/assignments/bert.ipynb
+++ b/assets/assignments/bert.ipynb
@@ -955,7 +955,7 @@
       },
       "outputs": [],
       "source": [
-        "def what_is(arithmetic_input, model, tokenizer):\n",
+        "def what_is(input, model, tokenizer):\n",
         "    # Use GPU, if available\n",
         "    device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
         "    model = model.to(device)\n",
@@ -964,7 +964,7 @@
         "    index_to_sentiment_map = {0: \"negative\", 1: \"zero\", 2: \"positive\"}\n",
         "    \n",
         "    tokenized_inputs = tokenizer(\n",
-        "        inputs.tolist(),          # Input text\n",
+        "        input,                    # Input text\n",
         "        add_special_tokens=True,  # add '[CLS]' and '[SEP]'\n",
         "        padding='max_length',     # pad to a length specified by the max_length\n",
         "        max_length=MAX_LEN,       # truncate all sentences longer than max_length\n",
@@ -989,7 +989,7 @@
       },
       "outputs": [],
       "source": [
-        "what_is(\"three minus two minus two\", model=mathbert, tokenizer=bert_tokenizer)"
+        "what_is(\"three minus five\", model=mathbert, tokenizer=bert_tokenizer)"
       ]
     },
     {
@@ -1000,7 +1000,7 @@
       },
       "outputs": [],
       "source": [
-        "what_is(\"three minus two minus two\", model=mathbert_frozen, tokenizer=bert_tokenizer)"
+        "what_is(\"three minus five\", model=mathbert_frozen, tokenizer=bert_tokenizer)"
       ]
     },
     {
@@ -1011,7 +1011,7 @@
       },
       "outputs": [],
       "source": [
-        "what_is(\"three minus two minus two\", model=bertweet, tokenizer=bert_tokenizer)"
+        "what_is(\"three minus five\", model=bertweet, tokenizer=bert_tokenizer)"
       ]
     }
   ],
@@ -1033,8 +1033,7 @@
         "RAFzVhML8mru"
       ],
       "name": "bert.ipynb",
-      "provenance": [],
-      "toc_visible": true
+      "provenance": []
     },
     "kernelspec": {
       "display_name": "Python 3",


### PR DESCRIPTION
There was a bug in the `what_is` function of the `bert` notebook that caused the same answer to be returned always. This has been fixed.