### PR TITLE
Fix typo in NMT notebook

### DIFF
--- a/assets/assignments/nmt.ipynb
+++ b/assets/assignments/nmt.ipynb
@@ -2314,7 +2314,8 @@
         "29ZjkXTNrUKb"
       ],
       "name": "nmt.ipynb",
-      "provenance": []
+      "provenance": [],
+      "toc_visible": true
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/assets/assignments/nmt.ipynb
+++ b/assets/assignments/nmt.ipynb
@@ -1581,7 +1581,7 @@
         "\n",
         "        Returns:\n",
         "            context: weighted average of the values (batch_size x k x hidden_size)\n",
-        "            attention_weights: Normalized attention weights for each encoder hidden state. (batch_size x seq_len x 1)\n",
+        "            attention_weights: Normalized attention weights for each encoder hidden state. (batch_size x seq_len x k)\n",
         "\n",
         "            The output must be a softmax weighting over the seq_len annotations.\n",
         "        \"\"\"\n",
@@ -1644,7 +1644,7 @@
         "\n",
         "        Returns:\n",
         "            context: weighted average of the values (batch_size x k x hidden_size)\n",
-        "            attention_weights: Normalized attention weights for each encoder hidden state. (batch_size x seq_len x 1)\n",
+        "            attention_weights: Normalized attention weights for each encoder hidden state. (batch_size x seq_len x k)\n",
         "\n",
         "            The output must be a softmax weighting over the seq_len annotations.\n",
         "        \"\"\"\n",
@@ -2314,8 +2314,7 @@
         "29ZjkXTNrUKb"
       ],
       "name": "nmt.ipynb",
-      "provenance": [],
-      "toc_visible": true
+      "provenance": []
     },
     "kernelspec": {
       "display_name": "Python 3",


### PR DESCRIPTION
There was a small typo in the nmt notebook, which had the final dimension of attention weights as `1` (and not `k`) in scaled dot product attention and casual dot product attention. This has been fixed.